### PR TITLE
chore(deps-dev): bump zod from 3.22.2 to 3.22.4 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11239,7 +11239,7 @@
         "postcss": "8.4.14",
         "styled-jsx": "5.1.1",
         "watchpack": "2.4.0",
-        "zod": "3.21.4"
+        "zod": "3.22.4"
       },
       "bin": {
         "next": "dist/bin/next"
@@ -14807,7 +14807,7 @@
     },
     "node_modules/zod": {
       "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -16723,7 +16723,7 @@
         "postcss": "8.4.14",
         "styled-jsx": "5.1.1",
         "watchpack": "2.4.0",
-        "zod": "3.21.4"
+        "zod": "3.22.4"
       }
     },
     "normalize-path": {
@@ -17470,8 +17470,8 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
     }
   }


### PR DESCRIPTION
Closes Dependabot alert #7 which is titled as "Zod denial of service vulnerability".

Fixes CVE-2023-4316 security vulnerability.

Description: Zod version 3.22.2 allows an attacker to perform a denial of service while validating emails.

Package: zod (npm)
Affected versions: <= 3.22.2
Patched version: 3.22.3
Bumped version: 3.22.4

Severity: Low
Tags: Direct dependency; Patch available
Weaknesses: CWE-1333
CVE ID: CVE-2023-4316
GHSA ID: GHSA-m95q-7qp3-xv42

Bumps [zod](https://github.com/colinhacks/zod) from 3.22.2 to 3.22.4.
- [Release notes](https://github.com/colinhacks/zod/releases)
- [Commits](https://github.com/colinhacks/zod/compare/3.22.2...3.22.4)

---
updated-dependencies:
- dependency-name: zod
  dependency-type: direct:development
...